### PR TITLE
fix: include .formatter.exs in package (again)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `import_deps: [:commandex]` in `.formatter.exs` works again.
+- `import_deps: [:commandex]` in `.formatter.exs` works again. ([#15](https://github.com/codedge-llc/commandex/pull/15))
 
 ## [0.5.0] - 2024-09-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.1] - 2024-09-09
+
+### Fixed
+
+- `import_deps: [:commandex]` in `.formatter.exs` works again.
+
 ## [0.5.0] - 2024-09-08
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Add commandex as a `mix.exs` dependency:
 ```elixir
 def deps do
   [
-    {:commandex, "~> 0.5.0"}
+    {:commandex, "~> 0.5.1"}
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Commandex.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/codedge-llc/commandex"
-  @version "0.5.0"
+  @version "0.5.1"
 
   def project do
     [
@@ -55,7 +55,7 @@ defmodule Commandex.MixProject do
   defp package do
     [
       description: "Make complex actions a first-class data type.",
-      files: ["lib", "mix.exs", "README*", "LICENSE*", "CHANGELOG*"],
+      files: ["lib", "mix.exs", ".formatter.exs", "README*", "LICENSE*", "CHANGELOG*"],
       licenses: ["MIT"],
       links: %{
         "Changelog" => "https://hexdocs.pm/commandex/changelog.html",


### PR DESCRIPTION
Accidentally left it out in the 0.5.0 release, breaking custom formatting for anyone who has upgraded already.